### PR TITLE
Apply Network Security Group to Subnet

### DIFF
--- a/eval/json/akshcihost.json
+++ b/eval/json/akshcihost.json
@@ -328,6 +328,7 @@
         "publicIpAddressSku": "Basic",
         "vnetId": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetId'), '/subnets/', variables('subnetName'))]",
+        "networkSecurityGroupRef": "[resourceId(Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
         "vmSkuGen1": "[if(equals(parameters('virtualMachineOS'), 'Windows Server 2022'), '2022-datacenter', '2019-datacenter')]",
         "vmSkuGen2": "[if(equals(parameters('virtualMachineOS'), 'Windows Server 2022'), '2022-datacenter-g2', '2019-datacenter-gensecond')]"
     },
@@ -372,6 +373,9 @@
                     },
                     "location": {
                         "value": "[resourceGroup().location]"
+                    },
+                    "networkSecurityGroup": {
+                        "value": "[variables('networkSecurityGroupRef')]"
                     }
                 }
             }
@@ -609,6 +613,9 @@
                     },
                     "location": {
                         "value": "[resourceGroup().location]"
+                    },
+                    "networkSecurityGroup": {
+                        "value": "[variables('networkSecurityGroupRef')]"
                     }
                 }
             }

--- a/eval/json/updatevnet.json
+++ b/eval/json/updatevnet.json
@@ -37,6 +37,12 @@
             "metadata": {
                 "description": "Location for all resources."
             }
+        },
+        "networkSecurityGroup": {
+            "type": "string",
+            "metadata": {
+                "description": "The network security group to use for the new subnet, in the new VNET"
+            }
         }
     },
     "resources": [
@@ -58,7 +64,8 @@
                     {
                         "name": "[parameters('subnetName')]",
                         "properties": {
-                            "addressPrefix": "[parameters('subnetRange')]"
+                            "addressPrefix": "[parameters('subnetRange')]",
+                            "networkSecurityGroup": "[parameters('networkSecurityGroup')]"
                         }
                     }
                 ]

--- a/eval/json/vnet.json
+++ b/eval/json/vnet.json
@@ -31,6 +31,12 @@
             "metadata": {
                 "description": "Location for all resources."
             }
+        },
+        "networkSecurityGroup": {
+            "type": "string",
+            "metadata": {
+                "description": "The network security group to use for the new subnet, in the new VNET"
+            }
         }
     },
     "resources": [
@@ -49,7 +55,8 @@
                     {
                         "name": "[parameters('subnetName')]",
                         "properties": {
-                            "addressPrefix": "[parameters('subnetRange')]"
+                            "addressPrefix": "[parameters('subnetRange')]",
+                            "networkSecurityGroup": "[parameters('networkSecurityGroup')]"
                         }
                     }
                 ]


### PR DESCRIPTION
This updates the evaluation ARM template to also apply the network security group to the subnet created on the virtual network.

This is required to comply with some security policies.